### PR TITLE
re2: Pre-install abseil headers for LogicFuzz wllvm compatibility

### DIFF
--- a/projects/re2/Dockerfile
+++ b/projects/re2/Dockerfile
@@ -22,4 +22,10 @@ RUN apt-get update -y && apt-get install -y cmake make pkg-config
 RUN git clone --depth=1 https://github.com/abseil/abseil-cpp
 RUN git clone --depth 1 https://github.com/google/re2
 
+# Pre-install abseil headers for LogicFuzz wllvm compilation
+# (cmake doesn't work well with wllvm wrapper, so we install headers first)
+RUN cd $SRC/abseil-cpp && mkdir -p build && cd build && \
+    cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && \
+    make -j$(nproc) && make install && ldconfig
+
 COPY build.sh $SRC/

--- a/projects/re2/build.sh
+++ b/projects/re2/build.sh
@@ -21,10 +21,13 @@ CXXFLAGS="$CXXFLAGS -O2"
 # https://github.com/abseil/abseil-cpp/issues/1524#issuecomment-1739364093
 # explains why Abseil must be built for fuzzing, not depended on normally.
 # N.B., this is pasted almost verbatim from what libphonenumber does here.
-cd $SRC/abseil-cpp
-mkdir build && cd build
-cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && make -j$(nproc) && make install
-ldconfig
+# Skip if already installed (for LogicFuzz wllvm compatibility - cmake doesn't work with wllvm)
+if [ ! -f /usr/local/include/absl/base/call_once.h ]; then
+    cd $SRC/abseil-cpp
+    mkdir build && cd build
+    cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && make -j$(nproc) && make install
+    ldconfig
+fi
 
 # Second, build and install RE2.
 # N.B., we don't follow the standard incantation for building RE2


### PR DESCRIPTION
cmake doesn't work well with wllvm wrapper, so we pre-install abseil headers in Dockerfile and skip the cmake build in build.sh when headers are already installed.

This allows LogicFuzz's LLVM API extraction to work with re2.